### PR TITLE
multiline create statements

### DIFF
--- a/sqlite_web/sqlite_web.py
+++ b/sqlite_web/sqlite_web.py
@@ -551,7 +551,7 @@ def value_filter(value, max_length=50):
     return value
 
 def _format_create_table(sql):
-    column_re = re.compile('(.+?)\((.+)\)')
+    column_re = re.compile('(.+?)\((.+)\)', re.S)
     column_split_re = re.compile(r'(?:[^,(]|\([^)]*\))+')
     create_table, column_list = column_re.search(sql).groups()
     columns = ['  %s' % column.strip()


### PR DESCRIPTION
sometimes the `CREATE` statement contains newline characters (seen this in django). 

add the regex flag allowing `.` matching on `\n`.
this fixes `SQL` in `structure` tab for some of my tables.

(on a related note, i know it's silly, why compile the same regexp
on every table view? :] )