### PR TITLE
a bit more resilient pagination

### DIFF
--- a/sqlite_web/templates/table_content.html
+++ b/sqlite_web/templates/table_content.html
@@ -56,6 +56,7 @@
       <li class="{% if not previous_page %}disabled {% endif %}previous">
         <a href="{{ url_for('table_content', table=table, page=previous_page) }}">&larr; Previous</a>
       </li>
+      <li>{{ page }} / {{ total_pages }}</li>
       <li class="{% if not next_page %}disabled {% endif %}next">
         <a href="{{ url_for('table_content', table=table, page=next_page) }}">Next &rarr;</a>
       </li>


### PR DESCRIPTION
take care of bogus `?page=` parameters including non-numbers
and out of range numbers.  also show a total in the pager bar.

as i needed non-float `total_pages`, i went with a simpler
calculation instead of `float` and `math.ceil`.

i personally find the disabled icons over non-disabled links that
will redirect the user away (e.g. if on the last page of the table)
but i did not change that.