### PR TITLE
Fix the image path for Windows

### DIFF
--- a/sqlite_web/sqlite_web.py
+++ b/sqlite_web/sqlite_web.py
@@ -613,7 +613,7 @@ def get_query_images():
     for filename in sorted(os.listdir(image_dir)):
         basename = os.path.splitext(os.path.basename(filename))[0]
         parts = basename.split('-')
-        accum.append((parts, os.path.join('img', filename)))
+        accum.append((parts, 'img/' + filename))
     return accum
 
 #


### PR DESCRIPTION
URLs should always use '/' as the separator. When running sqlite-web on Windows, `os.path.join()` uses '\\' as the separator, leading to incorrect URLs like `http://127.0.0.1:8080/static/img%5Cexpression.png`. This PR fixes this issue.