### PR TITLE
Fix: Fix typo in get_option_parser function 'extension' to 'extensions'

### DIFF
--- a/sqlite_web/sqlite_web.py
+++ b/sqlite_web/sqlite_web.py
@@ -761,7 +761,7 @@ def get_option_parser():
         help='URL prefix for application.')
     parser.add_option(
         '-e',
-        '--extension',
+        '--extensions',
         action='append',
         help='Path or name of loadable extension.')
     ssl_opts = optparse.OptionGroup(parser, 'SSL options')


### PR DESCRIPTION
Fix #90