### PR TITLE
Py3 compat / load as module

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ $ pip install sqlite-web
 
 ```sh
 $ sqlite_web /path/to/database.db
+
+for Python 3:
+$ python3 -m sqlite_web /path/to/database.db
 ```
 
 ### Features

--- a/sqlite_web/__main__.py
+++ b/sqlite_web/__main__.py
@@ -1,4 +1,10 @@
-from sqlite_web import main
+import sys
+
+# Py2k compat.
+if sys.version_info[0] == 2:
+    from sqlite_web import main
+else:
+    from .sqlite_web import main
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* When executing as a module in Python3 and executing as python3 -m sqlite_web <db>, execution fails with
from sqlite_web import main ImportError: cannot import name 'main' from 'sqlite_web'

* Updated readme