### PR TITLE
[feature] modify sqlite3 dependency to use a customized version

### DIFF
--- a/sqlite_web/sqlite_web.py
+++ b/sqlite_web/sqlite_web.py
@@ -68,7 +68,7 @@ else:
 
 from peewee import *
 from peewee import IndexMetadata
-from peewee import sqlite3
+import sqlite3
 from playhouse.dataset import DataSet
 from playhouse.migrate import migrate
 


### PR DESCRIPTION
First, thank you for sharing this project! It really makes using sqlite easy with UI.

I encountered a problem with replacing the `sqlite3` package when installing `sqlite-web`. I need to use a newer version of `sqlite3` library compiled by myself, so I installed it into my linux system path. Though I replaced the `sqlite3` library in my Python3 which gives the newer version, I cannot use the new features (e.g. alter table grammar) in `sqlite-web`. 

I checked the source code and found that sqlite3 package from` peewee` is used instead of the one provided by Python. Then I changed the line of code now the newer sqlite3 package is available in `sqlite-web`. I want to provide this one line change as a pull request for those who also need to do the same thing.