### PR TITLE
Use .container-fluid for a full width container, spanning the entire width of the viewport

### DIFF
--- a/sqlite_web/templates/base.html
+++ b/sqlite_web/templates/base.html
@@ -30,7 +30,7 @@
   </head>
 
   <body class="{% block body_class %}{% endblock %}">
-    <div class="container">
+    <div class="container-fluid">
       {% block page_header %}
         <div class="page-header">
           {% block content_header %}


### PR DESCRIPTION
Use .container-fluid for a full width container, spanning the entire width of the viewport.
Using the full width of the screen for wide tables is much more efficient. 