### PR TITLE
Publish on Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Publish on Docker Hub
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: ["master"]
+  release:
+    types: [published]
+
+jobs:
+
+  release_docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: pablocastellano/sqlite-web
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ github.ref_name == 'master' }}
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: ./docker
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This is working on my repo and I am publishing the docker images to https://hub.docker.com/repository/docker/pablocastellano/sqlite-web.

It requires configuring the following secrets
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN`