### PR TITLE
fix jsonargsrecommended warning

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,5 +46,5 @@ RUN apk update \
 EXPOSE 8080
 VOLUME /data
 WORKDIR /data
-SHELL ["/bin/bash", "-c"]
+SHELL ["/bin/ash", "-c"]
 CMD sqlite_web -H 0.0.0.0 -x $SQLITE_DATABASE

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,4 +46,5 @@ RUN apk update \
 EXPOSE 8080
 VOLUME /data
 WORKDIR /data
+SHELL ["/bin/bash", "-c"]
 CMD sqlite_web -H 0.0.0.0 -x $SQLITE_DATABASE


### PR DESCRIPTION
When building the docker image using the provided Dockerfile, this warning is reported:
```
WARN: JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 49)
```

Adding `SHELL ["/bin/ash", "-c"]` just before the `CMD` statement fixes this warning.
I chose `ash` as it is the default shell for apline.
