### PR TITLE
feat: Add media support and refresh UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,134 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if have platform-specific dependencies, or dependencies
+#   are not pinned, it may be better to ignore the Pipfile.lock.
+# Pipfile.lock
+
+# PEP 582; used by poetry, pdm and other tools
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 flask
 pygments
--e git+git://github.com/coleifer/peewee.git#egg=peewee
+peewee

--- a/sqlite_web/static/css/sqlbrowse.css
+++ b/sqlite_web/static/css/sqlbrowse.css
@@ -1,20 +1,84 @@
-div.page-header {
-  margin: 40px 0 20px;
-  padding-bottom: 9px;
-  border-bottom: 1px solid #f8f5f0;
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    background-color: #f8f9fa;
+    color: #212529;
 }
-#sidebar .nav>li>a {padding: 3px 10px;}
-h1>small {font-size: 50%;}
+
+.page-header {
+    margin: 20px 0;
+    padding-bottom: 9px;
+    border-bottom: 1px solid #dee2e6;
+}
+
+#sidebar {
+    background-color: #fff;
+    padding: 15px;
+    border-right: 1px solid #dee2e6;
+}
+
+#sidebar .nav>li>a {
+    padding: 5px 15px;
+    color: #343a40;
+}
+
+#sidebar .nav>li>a:hover {
+    background-color: #e9ecef;
+}
+
+h1 {
+    font-size: 2rem;
+}
+
+h1>small {
+    font-size: 65%;
+    color: #6c757d;
+}
+
+.table {
+    background-color: #fff;
+}
+
 table.cell-content td,
 table.cell-content th {
-    padding: 1px 4px 1px 4px;
-    border: 1px dotted #cccccc;
+    padding: 8px 12px;
+    border: 1px solid #dee2e6;
+    vertical-align: middle;
 }
-ul.pagination .page-item .page-link {
-    border-color: #aaaaaa !important;
-    color: #888;
+
+table.cell-content th {
+    background-color: #e9ecef;
 }
-ul.pagination .page-item.disabled .page-link {
-    border-color: #dee2e6 !important;
-    color: #aaa;
+
+.btn-primary {
+    background-color: #007bff;
+    border-color: #007bff;
+}
+
+.btn-secondary {
+    background-color: #6c757d;
+    border-color: #6c757d;
+}
+
+.alert {
+    border-radius: .25rem;
+}
+
+footer {
+    margin-top: 20px;
+    padding-top: 20px;
+    border-top: 1px solid #dee2e6;
+    color: #6c757d;
+    font-size: 0.9em;
+}
+
+code {
+    color: #e83e8c;
+    word-wrap: break-word;
+}
+
+.main-content {
+    background-color: #fff;
+    padding: 20px;
+    border: 1px solid #dee2e6;
+    border-radius: .25rem;
 }

--- a/sqlite_web/templates/base.html
+++ b/sqlite_web/templates/base.html
@@ -55,13 +55,15 @@
           {% block logout %}{% if login_required %}<a href="{{ url_for('logout') }}">Log-out</a>{% endif %}{% endblock %}
         </div>
         <div class="col-9" id="content">
-          {% for category, message in get_flashed_messages(with_categories=true) %}
-            <div class="alert alert-{{ category }} alert-dismissable">
-              <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-              <p>{{ message }}</p>
-            </div>
-          {% endfor %}
-          {% block content %}{% endblock %}
+          <div class="main-content">
+            {% for category, message in get_flashed_messages(with_categories=true) %}
+              <div class="alert alert-{{ category }} alert-dismissable">
+                <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+                <p>{{ message }}</p>
+              </div>
+            {% endfor %}
+            {% block content %}{% endblock %}
+          </div>
         </div>
       </div>
       <div class="row">

--- a/sqlite_web/templates/table_content.html
+++ b/sqlite_web/templates/table_content.html
@@ -25,9 +25,17 @@
         <tr>
           {% for field in field_names %}
             {% set value = row[field] %}
+            {% set media_type = value|get_media_type %}
             <td>
               {% if value is none %}
                 <code>NULL</code>
+              {% elif media_type == 'image' %}
+                <img src="data:image;base64,{{ value|b64encode }}" style="max-height: 100px; max-width: 100px;" />
+              {% elif media_type == 'video' %}
+                <video controls style="max-height: 100px; max-width: 100px;">
+                  <source src="{{ url_for('raw_cell_content', table=table, pk=row|encode_pk(table_pk), column=field) }}">
+                  Your browser does not support the video tag.
+                </video>
               {% else %}
                 {{ value|value_filter|safe }}
               {% endif %}

--- a/test_sqlite_web.py
+++ b/test_sqlite_web.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+import tempfile
+import sqlite3
+
+from sqlite_web import sqlite_web
+
+# Sample data
+GIF_EMPTY = b'GIF89a\x01\x00\x01\x00\x80\x00\x00\xff\xff\xff\x00\x00\x00!\xf9\x04\x01\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;'
+MP4_EMPTY = b'\x00\x00\x00\x18ftypmp42\x00\x00\x00\x00mp42isom'
+
+class SqliteWebTestCase(unittest.TestCase):
+    def setUp(self):
+        self.db_fd, self.db_path = tempfile.mkstemp()
+        self.app = sqlite_web.app
+        self.app.config['TESTING'] = True
+        sqlite_web.initialize_app(self.db_path)
+        self.client = self.app.test_client()
+
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("CREATE TABLE media (id INTEGER PRIMARY KEY, data BLOB)")
+            conn.execute("INSERT INTO media (id, data) VALUES (?, ?)", (1, GIF_EMPTY))
+            conn.execute("INSERT INTO media (id, data) VALUES (?, ?)", (2, MP4_EMPTY))
+            conn.execute("INSERT INTO media (id, data) VALUES (?, ?)", (3, b'just text'))
+
+    def tearDown(self):
+        os.close(self.db_fd)
+        os.unlink(self.db_path)
+
+    def test_table_content_media(self):
+        response = self.client.get('/media/content/')
+        self.assertEqual(response.status_code, 200)
+
+        html = response.get_data(as_text=True)
+        self.assertIn('<img src="data:image;base64,', html)
+        self.assertIn('<video controls', html)
+        self.assertIn('BLOB, 9 bytes', html)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces several new features and improvements to sqlite-web:

- **Image and Video Support:** The application now detects and displays images and videos stored as BLOBs in the database. This is handled by a new route that serves raw binary data with the correct content type, and new template filters that render the appropriate HTML tags.

- **UI Refresh:** The user interface has been updated with a modern stylesheet for a cleaner look and feel. This includes improved table styling, buttons, and a more consistent layout.

- **Easier to Use:** By displaying media directly in the browser, the application is now easier to use for databases containing images and videos.

- **Testing:** A new test suite has been added to verify the media display functionality. The dependencies in `requirements.txt` have also been updated to use the PyPI version of `peewee`.

- **.gitignore:** A `.gitignore` file has been added to exclude compiled Python files and other common temporary files from the repository.