### PR TITLE
Fix: Prevent AttributeError on query pages for composite primary keysUpdate sqlite_web.py

### DIFF
--- a/sqlite_web/sqlite_web.py
+++ b/sqlite_web/sqlite_web.py
@@ -354,10 +354,10 @@ def _query_view(template, table=None):
     if data_description is not None and table:
         col_names = [r[0] for r in data_description]
         pk = model_class._meta.primary_key
-        if not isinstance(pk, CompositeKey):
-            pk = pk.column_name
-            if pk in col_names:
-                pk_index = col_names.index(pk)
+        if hasattr(pk, 'column_name'):
+            pk_col_name = pk.column_name  # Use a new variable for clarity
+            if pk_col_name in col_names:
+                pk_index = col_names.index(pk_col_name)
 
     return render_template(
         template,


### PR DESCRIPTION
This PR fixes a bug that caused an `AttributeError: 'bool' object has no attribute 'column_name'` when viewing query results for a table with a composite primary key.

The issue occurred because `model._meta.primary_key` evaluates to `False` for composite keys. The code was attempting to access the `.column_name` attribute on this boolean value.

The fix is to use `hasattr(pk, 'column_name')` to safely check if the primary key is a field object before trying to access its attributes. This ensures the code works correctly for tables with single, composite, or no primary keys.