### PR TITLE
Fix signal handling by adding tini

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,9 +42,10 @@ RUN apk update \
       && pip install --upgrade pip \
       && pip install --no-cache-dir cython \
       && pip install --no-cache-dir flask peewee sqlite-web \
-      && apk del .build-deps
+      && apk del .build-deps \
+      && apk add --no-cache tini
 EXPOSE 8080
 VOLUME /data
 WORKDIR /data
-SHELL ["/bin/ash", "-c"]
-CMD sqlite_web -H 0.0.0.0 -x $SQLITE_DATABASE
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["sqlite_web", "-H", "0.0.0.0", "-x", "$SQLITE_DATABASE"]


### PR DESCRIPTION
Fix: https://github.com/coleifer/sqlite-web/issues/197

## Bug

The container doesn't respect SIGTERM signal. The only way to stop it is using SIGKILL.

## Fix

This PR adds `tini` wrapper for better handling and propagation signals to the app.

## Testing scenarios

Create empty sqlite DB using command: `sqlite3 /tmp/db.sqlite ""` as pre-requisite for the following steps.

Use the following template for Docker Compose in `compose.yaml` file:
```yaml
services:
  sqlite-web:
    image: <IMAGE>
    platform: linux/amd64
    ports:
      - 8080:8080
    volumes:
      - /tmp/db.sqlite:/data/db.sqlite
    environment:
      - SQLITE_DATABASE=/data/db.sqlite
```

### Previous state

```bash
# set image: ghcr.io/coleifer/sqlite-web:latest in compose.yaml
docker compose up
# enter Ctrl+C
# you have to wait 10 seconds since after that time the Docker sends SIGKILL
# it means that the container doesn't respect other signal
# also, you will see `sqlite-web-1 exited with code 137`
# code 137 = container was terminated by receiving a SIGKILL signal
```

### Current state (this PR)

```bash
# build image
cd docker/
docker build --platform linux/amd64 -t local/sqlite-web .
cd ../

# set image: local/sqlite-web in compose.yaml
docker compose up
# enter Ctrl+C
# the container stopped immediately with code 143
# code 143 = container was terminated by receiving a SIGTERM signal
```

## Details

- `tini` package must be added after deleting `.build-deps`
- use `tini` in ENTRYPOINT in Dockerfile
- fix syntax for CMD in Dockerfile
