### PR TITLE
fix(table_update): reorder columns before rendering

### DIFF
--- a/sqlite_web/sqlite_web.py
+++ b/sqlite_web/sqlite_web.py
@@ -849,6 +849,12 @@ def redirect_to_previous(table):
         kw['ordering'] = ordering
     return redirect(url_for('table_content', table=table, **kw))
 
+def reorder_and_zip(columns, fields):
+    # Reorder items in columns[] to match with the items in fields[]
+    columns_by_name = {column.name: column for column in columns}
+    reordered_columns = [columns_by_name[field.name] for field in fields]
+    return zip(reordered_columns, fields)
+
 @app.route('/<table>/update/<b64:pk>/', methods=['GET', 'POST'])
 @require_table
 def table_update(table, pk):
@@ -914,7 +920,7 @@ def table_update(table, pk):
         else:
             flash('No data was specified to be updated.', 'warning')
 
-    columns_fields = zip(columns, fields)
+    columns_fields = reorder_and_zip(columns, fields)
 
     return render_template(
         'table_update.html',


### PR DESCRIPTION
## Summary

This PR proposes reordering items in `columns[]` before zipping them with `fields[]` to address the incorrect display bug described in #204.

## Details

When we assign `fields = model._meta.sorted_fields`, the order of returned items implemented in `peewee` does not match with what's in `columns`, so "zipping" them as is for rendering seems to cause the mismatched presentation in the update form. This solution mitigates the issue by reordering the `columns[]` based on column names.

I saw that `columns_fields = zip(columns, fields)` also appears in `table_insert()`, but in that function both lists are formed in sync within a for loop. So, probably ordering mismatch won't happen there.

## Checks

Verified that the order of field labels match with the data and the CRUD operations are not affected by this change.

<img width="50%" height="50%" alt="table_two_update_fixed" src="https://github.com/user-attachments/assets/5feb187d-8d1d-4c71-8059-6452978d75b0" />
