### PR TITLE
Fix extension loading

### DIFF
--- a/sqlite_web/sqlite_web.py
+++ b/sqlite_web/sqlite_web.py
@@ -1604,7 +1604,7 @@ def initialize_dataset(filename):
 
     if dataset_config['extensions']:
         # Load extensions before performing introspection.
-        for ext in extensions:
+        for ext in dataset_config['extensions']:
             db.load_extension(ext)
 
     if dataset_config['startup_hook']:


### PR DESCRIPTION
Extensions don't work for me - I get `NameError: name 'extensions' is not defined` when I try `--extension /vec0` when mounting vec0.so into the container.

Seems to be a trivial bug in the handling code - this edit works for me.