### PR TITLE
Build multiarch container images

### DIFF
--- a/.github/workflows/build_latest_container.yml
+++ b/.github/workflows/build_latest_container.yml
@@ -3,20 +3,26 @@ on:
   push:
     branches:
       - master
+permissions:
+  contents: read
+  packages: write
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Build image
-        run: |
-          cd docker
-          docker build -t ghcr.io/coleifer/sqlite-web:latest .
+      - uses: actions/checkout@v7
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
-      - name: Upload latest container to registry
-        run: docker push ghcr.io/coleifer/sqlite-web:latest
+      - name: Build and publish multiarch image
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --tag ghcr.io/coleifer/sqlite-web:latest \
+            --push \
+            ./docker

--- a/.github/workflows/build_release_container.yml
+++ b/.github/workflows/build_release_container.yml
@@ -3,20 +3,26 @@ on:
   push:
     tags:
       - '*'
+permissions:
+  contents: read
+  packages: write
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Build image
-        run: |
-          cd docker
-          docker build -t ghcr.io/coleifer/sqlite-web:${{  github.ref_name }} .
+      - uses: actions/checkout@v7
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
-      - name: Upload versioned container to registry
-        run: docker push ghcr.io/coleifer/sqlite-web:${{  github.ref_name }}
+      - name: Build and publish multiarch image
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --tag ghcr.io/coleifer/sqlite-web:${{ github.ref_name }} \
+            --push \
+            ./docker


### PR DESCRIPTION
I'm in need of an arm64 version of the Docker container, so I updated the CI to what I think the most streamlined way to do multiarch builds would be.  Similar to what https://github.com/coleifer/sqlite-web/pull/187 is trying to accomplish, but with less changes and using standard docker Github actions.   